### PR TITLE
Separate tasks for cljs devtools and dirac

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 * boot-cljs-devtools
 ** About
-[[https://github.com/boot-clj/boot][Boot]] task introducing enhancements to CLJS development in Chrome, specifically [[https://github.com/binaryage/cljs-devtools][CLJS DevTools]] and [[https://github.com/binaryage/dirac][Dirac]].
+[[https://github.com/boot-clj/boot][Boot]] tasks introducing enhancements to CLJS development in Chrome, specifically [[https://github.com/binaryage/cljs-devtools][CLJS DevTools]] and [[https://github.com/binaryage/dirac][Dirac]].
 ** Installation
 Latest version:
 
@@ -8,25 +8,50 @@ Latest version:
 
 In order to install it, add the following to your =build.boot= dependencies:
 #+BEGIN_SRC clojure
-[binaryage/devtools      "0.8.2" :scope "test"]
-[binaryage/dirac         "0.7.1" :scope "test"]
+[binaryage/devtools      "X.X.X" :scope "test"] ;; when you want cljd-devtools or both, replace X.X.X for current version
+[binaryage/dirac         "X.X.X" :scope "test"] ;; when you want dirac or both, replace X.X.X for current version
 [powerlaces/boot-cljs-devtools "0.X.X" :scope "test"]
 [org.clojure/clojurescript "1.9.293"] ;; see below
 #+END_SRC
 Note that boot-cljs-devtools requires ClojureScript version 1.9.89 or later for its =:preloads= feature.
 
-In addition require the task, specifically =cljs-devtools=.
+In addition require the task, specifically =cljs-devtools=:
 #+BEGIN_SRC clojure
 (require '[powerlaces.boot-cljs-devtools :refer [cljs-devtools]])
 #+END_SRC
+
+or specifically =dirac=:
+#+BEGIN_SRC clojure
+(require '[powerlaces.boot-cljs-devtools :refer [dirac]])
+#+END_SRC
+
+or both =cljs-devtools= and =dirac=:
+#+BEGIN_SRC clojure
+(require '[powerlaces.boot-cljs-devtools :refer [cljs-devtools dirac]])
+#+END_SRC
+
 Currently files may be generated in the =out= directory, so it would be advisable to add that to someplace like in a =.gitignore=.
 ** Usage
 Ensure that this task runs before the =cljs= and after the =watch= task and that you include a =.cljs.edn= file according to [[https://github.com/adzerk-oss/boot-cljs/wiki/Usage#multiple-builds][this]].
-Task example:
+
+Task example for cljs-devtools:
 #+BEGIN_SRC clojure
 (deftask dev []
   (comp (watch) (cljs-devtools) (cljs)))
 #+END_SRC
+
+Task example for dirac:
+#+BEGIN_SRC clojure
+(deftask dev []
+  (comp (watch) (dirac) (cljs)))
+#+END_SRC
+
+Task example for both cljs-devtools and dirac:
+#+BEGIN_SRC clojure
+(deftask dev []
+  (comp (watch) (cljs-devtools) (dirac) (cljs)))
+#+END_SRC
+
 File =your-ns.cljs.edn= example:
 #+BEGIN_SRC clojure
 {:require  [your-ns.core]

--- a/src/powerlaces/boot_cljs_devtools.clj
+++ b/src/powerlaces/boot_cljs_devtools.clj
@@ -9,16 +9,18 @@
 
 (def ^:private deps '#{binaryage/devtools binaryage/dirac})
 
-(defn- add-preloads! [in-file out-file]
-  (let [preloads ['devtools.preload 'dirac.runtime.preload]
-        spec (-> in-file slurp read-string)]
+(def ^:private preloads {:cljs-devtools 'devtools.preload :dirac 'dirac.runtime.preload})
+
+(defn- add-preload! [lib in-file out-file]
+  (let [spec (-> in-file slurp read-string)
+        preload (get preloads lib)]
     (when (not= :nodejs (-> spec :compiler-options :target))
       (util/info
        "Adding :preloads %s to %s...\n"
-       preloads (.getName in-file))
+       preload (.getName in-file))
       (io/make-parents out-file)
       (-> spec
-          (update-in [:compiler-options :preloads] #(into preloads %))
+          (update-in [:compiler-options :preloads] #(conj % preload))
           pr-str
           ((partial spit out-file))))))
 
@@ -52,10 +54,27 @@
    :middleware ['dirac.nrepl/middleware]})
 
 (boot/deftask cljs-devtools
-  "Add Chrome Devtool enhancements for ClojureScript development."
-  [b ids        BUILD_IDS  #{str} "Only inject devtools into these builds (= .cljs.edn files)"
-   n nrepl-opts NREPL_OPTS edn     "Options passed to boot's `repl` task."
-   d dirac-opts DIRAC_OPTS edn     "Options passed to dirac."]
+  "Add Chrome cljs-devtools enhancements for ClojureScript development."
+  [b ids BUILD_IDS  #{str} "Only inject devtools into these builds (= .cljs.edn files)"]
+  (let [tmp (boot/tmp-dir!)
+        prev (atom nil)]
+    (comp
+     (boot/with-pre-wrap fileset
+       (doseq [f (relevant-cljs-edn @prev fileset ids)]
+         (let [path (boot/tmp-path f)
+               in-file (boot/tmp-file f)
+               out-file (io/file tmp path)]
+           (add-preload! :cljs-devtools in-file out-file)))
+       (reset! prev fileset)
+       (-> fileset
+           (boot/add-resource tmp)
+           (boot/commit!))))))
+
+(boot/deftask dirac
+  "Add dirac enhancements for ClojureScript development."
+  [b ids BUILD_IDS #{str} "Only inject devtools into these builds (= .cljs.edn files)"
+   n nrepl-opts NREPL_OPTS edn "Options passed to boot's `repl` task."
+   d dirac-opts DIRAC_OPTS edn "Options passed to dirac."]
   (let [tmp (boot/tmp-dir!)
         prev (atom nil)
         nrepl-opts (cond-> (merge nrepl-defaults nrepl-opts)
@@ -75,8 +94,7 @@
          (let [path (boot/tmp-path f)
                in-file (boot/tmp-file f)
                out-file (io/file tmp path)]
-           (io/make-parents out-file)
-           (add-preloads! in-file out-file)))
+           (add-preload! :dirac in-file out-file)))
        (reset! prev fileset)
        (-> fileset
            (boot/add-resource tmp)


### PR DESCRIPTION
* Separate tasks for cljs devtools and dirac

* Fix cljs-devtools task

* Change cljs-devtools and dirac versions in README

* Add both separated tasks to README

* Fix formatting and versions in README

* Refactor preloads' adding

Also removed redundant make-parents